### PR TITLE
Fix mouse side button clicks being ignored

### DIFF
--- a/hookmap-core/src/sys/windows/hook.rs
+++ b/hookmap-core/src/sys/windows/hook.rs
@@ -209,8 +209,12 @@ fn into_mouse_event_target(w_param: WPARAM, hook: &MSLLHOOKSTRUCT) -> Option<Mou
         WM_LBUTTONDOWN | WM_LBUTTONUP => Button::LeftButton,
         WM_RBUTTONDOWN | WM_RBUTTONUP => Button::RightButton,
         WM_MBUTTONDOWN | WM_MBUTTONUP => Button::MiddleButton,
-        WM_XBUTTONDOWN | WM_XBUTTONUP if hook.mouseData == XBUTTON1 => Button::SideButton1,
-        WM_XBUTTONDOWN | WM_XBUTTONUP if hook.mouseData == XBUTTON2 => Button::SideButton2,
+        WM_XBUTTONDOWN | WM_XBUTTONUP if hook.mouseData.0 >> 16 == XBUTTON1.0 => {
+            Button::SideButton1
+        }
+        WM_XBUTTONDOWN | WM_XBUTTONUP if hook.mouseData.0 >> 16 == XBUTTON2.0 => {
+            Button::SideButton2
+        }
         _ => return None,
     };
     Some(MouseEventTarget::Button(mouse_button))


### PR DESCRIPTION
Fix mouse side button clicks being ignored in Windows.
Constants `XBUTTON1` and `XBUTTON2` are only make up the high-order 16 bits of the `mouseData`.

Close #2 

### Remarks

The latest win32metadata release [v39.0.18-preview](https://github.com/microsoft/win32metadata/releases/tag/v39.0.18-preview) changed the types for those variables. The future `windows-rs` releases (presumably v0.44 and up) will have the changed types.

- `MSLLHOOKSTRUCT.mouseData`: `u32` instead of `struct MOUSEHOOKSTRUCTEX_MOUSE_DATA(pub u32)`
- `XBUTTON1` and `XBUTTON2`: `u16` instead of `struct MOUSEHOOKSTRUCTEX_MOUSE_DATA(pub u32)`

The bit shifting will still be needed in the future versions of `windows-rs`, however, the variables will no longer be wrapped inside a struct, so the code should be updated to reflect those type changes.