### PR TITLE
Support some of the multimedia keys

### DIFF
--- a/hookmap-core/src/button.rs
+++ b/hookmap-core/src/button.rs
@@ -192,6 +192,14 @@ pub enum Button {
     F24,
     PrintScreen,
 
+    VolumeMute,
+    VolumeDown,
+    VolumeUp,
+    MediaNext,
+    MediaPrevious,
+    MediaStop,
+    MediaPlayPause,
+
     Shift,
     Ctrl,
     Alt,

--- a/hookmap-core/src/sys/windows/vkcode.rs
+++ b/hookmap-core/src/sys/windows/vkcode.rs
@@ -176,6 +176,15 @@ pub(super) const fn into_button(vkcode: VIRTUAL_KEY) -> Option<Button> {
         VK_F23 => F23,
         VK_F24 => F24,
         VK_SNAPSHOT => PrintScreen,
+
+        VK_VOLUME_MUTE => VolumeMute,
+        VK_VOLUME_DOWN => VolumeDown,
+        VK_VOLUME_UP => VolumeUp,
+        VK_MEDIA_NEXT_TRACK => MediaNext,
+        VK_MEDIA_PREV_TRACK => MediaPrevious,
+        VK_MEDIA_STOP => MediaStop,
+        VK_MEDIA_PLAY_PAUSE => MediaPlayPause,
+
         _ => return None,
     })
 }
@@ -354,6 +363,14 @@ pub(super) const fn from_button(button: Button) -> VIRTUAL_KEY {
         F23 => VK_F23,
         F24 => VK_F24,
         PrintScreen => VK_SNAPSHOT,
+
+        VolumeMute => VK_VOLUME_MUTE,
+        VolumeDown => VK_VOLUME_DOWN,
+        VolumeUp => VK_VOLUME_UP,
+        MediaNext => VK_MEDIA_NEXT_TRACK,
+        MediaPrevious => VK_MEDIA_PREV_TRACK,
+        MediaStop => VK_MEDIA_STOP,
+        MediaPlayPause => VK_MEDIA_PLAY_PAUSE,
 
         Shift | Ctrl | Alt | Super => unreachable!(),
     }


### PR DESCRIPTION
Add support for the multimedia keys that my keyboard have: `Mute`, `Volume Up`, `Volume Down`, `Media Stop`, `Media Previous`, `Media Play/Pause`, `Media Next`.

It seems there are other multimedia keys supported both in Windows and Linux, such as `Search`, `Favorites`, `Home`, `Mail`, `Sleep`, etc. However, those keys are not added because I couldn't test them using my current keyboard.

Close #3 

### Tests

Manually tested using following code.
```rust
use hookmap::prelude::*;

fn main() {
    let mut hotkey = Hotkey::new();
    hotkey
        .register(Context::new())
        .on_press(Button::VolumeMute, |_| {
            println!("VolumeMute");
        })
        .on_press(Button::VolumeDown, |_| {
            println!("VolumeDown");
        })
        .on_press(Button::VolumeUp, |_| {
            println!("VolumeUp");
        })
        .on_press(Button::MediaNext, |_| {
            println!("MediaNext");
        })
        .on_press(Button::MediaPrevious, |_| {
            println!("MediaPrevious");
        })
        .on_press(Button::MediaStop, |_| {
            println!("MediaStop");
        })
        .on_press(Button::MediaPlayPause, |_| {
            println!("MediaPlayPause");
        })
        .remap(Button::Key1, Button::VolumeMute)
        .remap(Button::Key2, Button::VolumeDown)
        .remap(Button::Key3, Button::VolumeUp)
        .remap(Button::Key4, Button::MediaNext)
        .remap(Button::Key5, Button::MediaPrevious)
        .remap(Button::Key6, Button::MediaStop)
        .remap(Button::Key7, Button::MediaPlayPause);
    hotkey.install();
}

```